### PR TITLE
Improvement/dynamicly sized canvas

### DIFF
--- a/src/EchoCamera.tsx
+++ b/src/EchoCamera.tsx
@@ -19,7 +19,11 @@ const EchoCamera = () => {
       <ScanningArea captureAreaRef={scanArea} />
 
       {viewfinder.current && canvas.current && scanArea.current && (
-        <Scanner viewfinder={viewfinder} canvas={canvas} scanArea={scanArea} />
+        <Scanner
+          viewfinder={viewfinder.current}
+          canvas={canvas.current}
+          scanArea={scanArea.current}
+        />
       )}
     </Main>
   );

--- a/src/Scanner.tsx
+++ b/src/Scanner.tsx
@@ -23,9 +23,9 @@ import {
 } from '@utils';
 
 interface ScannerProps {
-  viewfinder: RefObject<HTMLVideoElement>;
-  canvas: RefObject<HTMLCanvasElement>;
-  scanArea: RefObject<HTMLElement>;
+  viewfinder: HTMLVideoElement;
+  canvas: HTMLCanvasElement;
+  scanArea: HTMLElement;
 }
 function Scanner({ viewfinder, canvas, scanArea }: ScannerProps) {
   const [validatedTags, setValidatedTags] = useState<
@@ -72,7 +72,7 @@ function Scanner({ viewfinder, canvas, scanArea }: ScannerProps) {
     changeTagScanStatus('scanning', true);
 
     // Capture image.
-    let scans = await tagScanner.scan(scanArea.current.getBoundingClientRect());
+    let scans = await tagScanner.scan(scanArea.getBoundingClientRect());
 
     // Run OCR and validation to get possible tag numbers.
     const validatedTags = await tagScanner.ocr(scans);

--- a/src/components/viewfinder/CaptureArea.tsx
+++ b/src/components/viewfinder/CaptureArea.tsx
@@ -1,38 +1,19 @@
-import React, { RefObject, useEffect, useState } from 'react';
+import React, { RefObject } from 'react';
 import styled from 'styled-components';
+
+import { Dimensions, useScanningAreaDimensions } from './viewFinderUtils';
 
 interface ScanningAreaProps {
   captureAreaRef: RefObject<HTMLElement>;
 }
 
-type ScanningAreaDimensions = {
-  width: number;
-  height: number;
-};
-
 const ScanningArea = (props: ScanningAreaProps): JSX.Element => {
-  const [dimensions, setDimensions] = useState<ScanningAreaDimensions>(
-    getDimensions()
-  );
-
-  // Handles the resize of the scanning area whenever the viewport dimensions changes.
-  // TODO: Consider debounce and/or only run if the device is rotated.
-  useEffect(() => {
-    function handleResize() {
-      setDimensions(getDimensions());
-    }
-
-    globalThis.addEventListener('resize', handleResize);
-
-    return function cleanup() {
-      globalThis.removeEventListener('resize', handleResize);
-    };
-  }, []);
+  const dimensions = useScanningAreaDimensions();
 
   return <SvgContainer ref={props.captureAreaRef} dimensions={dimensions} />;
 };
 
-const SvgContainer = styled.section<{ dimensions: ScanningAreaDimensions }>`
+const SvgContainer = styled.section<{ dimensions: Dimensions }>`
   // Centering of absolutely placed elements
   position: absolute;
   top: 50%;
@@ -44,27 +25,5 @@ const SvgContainer = styled.section<{ dimensions: ScanningAreaDimensions }>`
   height: ${(props) => props.dimensions.height}px;
   border: 3px dotted var(--outOfService);
 `;
-
-function getDimensions() {
-  const viewMode = getViewMode();
-
-  if (viewMode === 'portrait') {
-    return {
-      width: globalThis.innerWidth * 0.8,
-      height: globalThis.innerHeight * (1 / 3)
-    };
-  } else {
-    return {
-      width: globalThis.innerWidth * 0.6,
-      height: globalThis.innerHeight * (1 / 3)
-    };
-  }
-
-  function getViewMode(): 'portrait' | 'landscape' {
-    // We default to portrait if the height and width are equal.
-    if (globalThis.innerHeight >= globalThis.innerWidth) return 'portrait';
-    else return 'landscape';
-  }
-}
 
 export { ScanningArea };

--- a/src/components/viewfinder/Viewfinder.tsx
+++ b/src/components/viewfinder/Viewfinder.tsx
@@ -46,9 +46,6 @@ const ViewFinder = styled.video`
   object-fit: cover;
 `;
 
-const Canvas = styled.canvas`
-  width: 500px;
-  height: 300px;
-`;
+const Canvas = styled.canvas``;
 
 export { Viewfinder };

--- a/src/components/viewfinder/Viewfinder.tsx
+++ b/src/components/viewfinder/Viewfinder.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
-import styled from "styled-components"
-import { VideoHTMLAttributes, CanvasHTMLAttributes, RefObject } from 'react';
+import React, {
+  VideoHTMLAttributes,
+  CanvasHTMLAttributes,
+  RefObject
+} from 'react';
+import styled from 'styled-components';
 
+import { useScanningAreaDimensions } from './viewFinderUtils';
 interface ViewfinderProps {
   canvasRef: RefObject<HTMLCanvasElement>;
   videoRef: RefObject<HTMLVideoElement>;
@@ -10,6 +14,8 @@ interface ViewfinderProps {
 }
 
 const Viewfinder = (props: ViewfinderProps): JSX.Element => {
+  const dimensions = useScanningAreaDimensions();
+
   return (
     <>
       <ViewFinder
@@ -24,9 +30,8 @@ const Viewfinder = (props: ViewfinderProps): JSX.Element => {
       />
       <Canvas
         ref={props.canvasRef}
-        // TODO: set dynamic dimensions
-        width={'500'}
-        height="300"
+        width={dimensions.width}
+        height={dimensions.height}
         {...props.canvasOptions}
       />
     </>

--- a/src/components/viewfinder/viewFinderUtils.ts
+++ b/src/components/viewfinder/viewFinderUtils.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+import EchoUtils from '@equinor/echo-utils';
+
+import { debounce } from '@utils';
+
+export type Dimensions = {
+  width: number;
+  height: number;
+};
+
+export function useScanningAreaDimensions() {
+  const [dimensions, setDimensions] = useState<Dimensions>(getDimensions());
+
+  // Handles the resize of the scanning area whenever the viewport dimensions changes.
+  EchoUtils.Hooks.useEffectAsync(async (signal) => {
+    const handleResize = debounce(() => {
+      if (signal.aborted) return;
+      const dimensions = getDimensions();
+      setDimensions(dimensions);
+    });
+
+    globalThis.addEventListener('resize', handleResize);
+
+    return function cleanup() {
+      globalThis.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return dimensions;
+}
+
+function getDimensions(): Dimensions {
+  const viewMode = getViewMode();
+
+  if (viewMode === 'portrait') {
+    return {
+      width: globalThis.innerWidth * 0.8,
+      height: globalThis.innerHeight * (1 / 3)
+    };
+  } else {
+    return {
+      width: globalThis.innerWidth * 0.6,
+      height: globalThis.innerHeight * (1 / 3)
+    };
+  }
+
+  function getViewMode(): 'portrait' | 'landscape' {
+    // We default to portrait if the height and width are equal.
+    if (globalThis.innerHeight >= globalThis.innerWidth) return 'portrait';
+    else return 'landscape';
+  }
+}

--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -25,13 +25,13 @@ class Camera extends Postprocessor {
   };
 
   public pauseViewfinder(): boolean {
-    this._viewfinder.current.pause();
-    return this._viewfinder.current.paused;
+    this._viewfinder.pause();
+    return this._viewfinder.paused;
   }
 
   public resumeViewfinder(): boolean {
-    this._viewfinder.current.play();
-    return this._viewfinder.current.paused;
+    this._viewfinder.play();
+    return this._viewfinder.paused;
   }
 
   public alterZoom = (
@@ -79,7 +79,7 @@ class Camera extends Postprocessor {
           dWidth: captureArea.width
         };
         var captureBlob = await this._canvasHandler.draw(
-          this._viewfinder.current,
+          this._viewfinder,
           params
         );
       }

--- a/src/core/CanvasHandler.ts
+++ b/src/core/CanvasHandler.ts
@@ -1,5 +1,3 @@
-import { RefObject } from 'react';
-
 export type DrawImageParameters = {
   sx?: number;
   sy?: number;
@@ -19,7 +17,7 @@ type CanvasDimensions = {
 type AllowedMimeTypes = 'image/bmp' | 'image/png' | 'image/jpeg' | 'image/tiff';
 
 interface CanvasHandlerProps {
-  canvasRef: RefObject<HTMLCanvasElement>;
+  canvas: HTMLCanvasElement;
 }
 
 /**
@@ -31,15 +29,15 @@ class CanvasHandler {
   private readonly _standardCanvasDimensions: CanvasDimensions;
 
   constructor(props: CanvasHandlerProps) {
-    if (props.canvasRef == null)
+    if (!props.canvas)
       throw new Error(
         'Could not construct CanvasHandler. The canvas element reference is missing.'
       );
-    this._canvas = props.canvasRef.current;
-    this._canvasContext = props.canvasRef.current.getContext('2d');
+    this._canvas = props.canvas;
+    this._canvasContext = this._canvas.getContext('2d');
     this._standardCanvasDimensions = {
-      width: props.canvasRef.current.width,
-      height: props.canvasRef.current.height
+      width: this._canvas.width,
+      height: this._canvas.height
     };
   }
 

--- a/src/core/CoreCamera.ts
+++ b/src/core/CoreCamera.ts
@@ -4,8 +4,8 @@ import { ErrorRegistry } from '@enums';
 
 export interface CameraProps {
   mediaStream: MediaStream;
-  viewfinder: RefObject<HTMLVideoElement>;
-  canvas?: RefObject<HTMLCanvasElement>;
+  viewfinder: HTMLVideoElement;
+  canvas: HTMLCanvasElement;
   additionalCaptureOptions?: DisplayMediaStreamConstraints;
 }
 
@@ -15,21 +15,18 @@ export interface CameraProps {
 class CoreCamera {
   protected _cameraEnabled = true;
   protected _mediaStream: MediaStream;
-  protected _viewfinder: RefObject<HTMLVideoElement>;
+  protected _viewfinder: HTMLVideoElement;
   protected _videoTrack?: MediaStreamTrack;
-  public _capabilities?: MediaTrackCapabilities = undefined;
   protected _settings?: MediaTrackSettings;
+  public _capabilities?: MediaTrackCapabilities = undefined;
 
   constructor(props: CameraProps) {
     this._viewfinder = props.viewfinder;
-
     this._mediaStream = props.mediaStream;
     this._videoTrack = props.mediaStream.getVideoTracks()[0];
     this._capabilities = this._videoTrack.getCapabilities();
-    this._settings = this.videoTrack.getSettings();
-    if (this._viewfinder.current) {
-      this._viewfinder.current.srcObject = props.mediaStream;
-    }
+    this._settings = this._videoTrack.getSettings();
+    this._viewfinder.srcObject = props.mediaStream;
   }
 
   /**
@@ -74,7 +71,6 @@ class CoreCamera {
       throw new Error(error);
     }
   }
-
 
   public get videoTrack(): MediaStreamTrack | undefined {
     return this._videoTrack;
@@ -130,13 +126,13 @@ class CoreCamera {
     console.group('Starting camera');
     console.info(
       'Camera resolution -> ',
-      this._viewfinder.current.videoWidth,
-      this._viewfinder.current.videoHeight
+      this._viewfinder.videoWidth,
+      this._viewfinder.videoHeight
     );
     console.info(
       'Viewfinder dimensions -> ',
-      this._viewfinder.current.width,
-      this._viewfinder.current.height
+      this._viewfinder.width,
+      this._viewfinder.height
     );
     console.info(
       'Camera is capable of zooming: ',

--- a/src/core/Postprocessor.ts
+++ b/src/core/Postprocessor.ts
@@ -12,14 +12,14 @@ type CropInstructions = {
  */
 class Postprocessor extends CoreCamera {
   protected _capture?: Blob;
-  protected _canvas?: RefObject<HTMLCanvasElement>;
+  protected _canvas: HTMLCanvasElement;
   protected _cropDimensions: CropInstructions;
   protected _canvasHandler: CanvasHandler;
 
   constructor(props: CameraProps) {
     super(props);
     this._canvas = props.canvas;
-    this._canvasHandler = new CanvasHandler({ canvasRef: props.canvas });
+    this._canvasHandler = new CanvasHandler({ canvas: props.canvas });
   }
 
   protected get capture() {

--- a/src/hooks/useMountCamera.ts
+++ b/src/hooks/useMountCamera.ts
@@ -1,10 +1,4 @@
-import {
-  Dispatch,
-  RefObject,
-  SetStateAction,
-  useEffect,
-  useState
-} from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import EchoUtils from '@equinor/echo-utils';
 
 import { TagScanner } from '../core/Scanner';
@@ -18,8 +12,8 @@ type CameraInfrastructure = {
 
 const { useEffectAsync } = EchoUtils.Hooks;
 export function useMountScanner(
-  viewfinder: RefObject<HTMLVideoElement>,
-  canvas: RefObject<HTMLCanvasElement>
+  viewfinder: HTMLVideoElement,
+  canvas: HTMLCanvasElement
 ): CameraInfrastructure {
   // Zoom controls. Currently only Android.
   const [zoomRef, setZoomInputRef] = useState<HTMLInputElement>(null);
@@ -65,7 +59,7 @@ export function useMountScanner(
   }, [tagScanner, zoomRef]);
 
   // Handle multitouch events.
-  viewfinder.current?.addEventListener(
+  viewfinder.addEventListener(
     'touchstart',
     (e) => {
       if (e.touches.length > 1) {

--- a/src/utils/func.ts
+++ b/src/utils/func.ts
@@ -1,0 +1,10 @@
+export function debounce(func: Function, timeout = 300) {
+  let timer: NodeJS.Timeout;
+
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './array';
 export * from './capabilities';
 export * from './event';
+export * from './func';
 export * from './error';
 export * from './url';
 export * from './business';


### PR DESCRIPTION
- Removed all handling of ref.current and undefined as this shouldn't be necessary as we're only passing down HTMLElements as props instead of ref objects.
- Resize in CaptureArea is now debounced
- CaptureArea handleResize is now also shared with ViewFinder and applied to Canvas width/height