### PR TITLE
Bug/search results overlap

### DIFF
--- a/src/components/searchresults/SearchResults.tsx
+++ b/src/components/searchresults/SearchResults.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
-
+import { getNotificationDispatcher as dispatchNotification } from '@utils';
 import { Button, Scrim } from '@equinor/eds-core-react';
 import { TagContextMenu, TagIcon, getIcon } from '@equinor/echo-components';
 import { getLegendStatusColor } from '@equinor/echo-framework';
@@ -60,16 +60,11 @@ const SearchResults = (props: SearchResultsProps): JSX.Element => {
       </Scrim>
     );
   } else {
-    return (
-      <Scrim open>
-        <NoSearchResultsWrapper>
-          <NoSearchResultsMessage>No tags detected.</NoSearchResultsMessage>
-          <ScanAgainButton variant="contained" onClick={props.onClose}>
-            <ButtonLabel>Scan again</ButtonLabel>
-          </ScanAgainButton>
-        </NoSearchResultsWrapper>
-      </Scrim>
-    );
+    dispatchNotification({
+      message: 'No tags detected.',
+      autohideDuration: 2000
+    })();
+    return null;
   }
 };
 

--- a/src/components/searchresults/SearchResults.tsx
+++ b/src/components/searchresults/SearchResults.tsx
@@ -25,7 +25,7 @@ const SearchResults = (props: SearchResultsProps): JSX.Element => {
       console.groupEnd();
     }
 
-    logTagSummaries();
+    EchoEnv.isDevelopment && logTagSummaries();
   }, [props.tagSummary]);
 
   function createSearchResult(tag: TagSummaryDto, index: number) {

--- a/src/components/searchresults/SearchResults.tsx
+++ b/src/components/searchresults/SearchResults.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { getNotificationDispatcher as dispatchNotification } from '@utils';
-import { Button, Scrim } from '@equinor/eds-core-react';
+import { Button } from '@equinor/eds-core-react';
 import { TagContextMenu, TagIcon, getIcon } from '@equinor/echo-components';
 import { getLegendStatusColor } from '@equinor/echo-framework';
 import { TagSummaryDto } from '@equinor/echo-search';
+import { EchoEnv } from '@equinor/echo-core';
 
 interface SearchResultsProps {
   tagSummary: TagSummaryDto[];
@@ -14,7 +15,6 @@ interface SearchResultsProps {
 
 const SearchResults = (props: SearchResultsProps): JSX.Element => {
   // Log new tag summaries as they arrive.
-  // TODO: Make this only run in non-prod envs.
   useEffect(() => {
     function logTagSummaries() {
       if (props.tagSummary.length > 0) {
@@ -50,14 +50,12 @@ const SearchResults = (props: SearchResultsProps): JSX.Element => {
 
   if (props.tagSummary.length > 0) {
     return (
-      <Scrim open>
-        <InvisibleWrapper>
-          {props.tagSummary.map(createSearchResult)}
-          <ScanAgainButton variant="contained" onClick={props.onClose}>
-            <ButtonLabel>Scan again</ButtonLabel>
-          </ScanAgainButton>
-        </InvisibleWrapper>
-      </Scrim>
+      <InvisibleWrapper>
+        {props.tagSummary.map(createSearchResult)}
+        <Button variant="contained" onClick={props.onClose}>
+          <ButtonLabel>Scan again</ButtonLabel>
+        </Button>
+      </InvisibleWrapper>
     );
   } else {
     dispatchNotification({
@@ -72,27 +70,11 @@ const ButtonLabel = styled.span`
   white-space: nowrap;
 `;
 
-const NoSearchResultsMessage = styled.p``;
-
-const ScanAgainButton = styled(Button)``;
-
-const DialogContentWrapper = styled.div`
-  pointer-events: all;
-
+const InvisibleWrapper = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const InvisibleWrapper = styled(DialogContentWrapper)`
+  pointer-events: all;
   gap: var(--medium);
-`;
-
-const NoSearchResultsWrapper = styled(DialogContentWrapper)`
-  background-color: var(--white);
-  justify-content: center;
-  z-index: 2;
-  height: auto;
-  padding: var(--medium);
 `;
 
 const SearchResult = styled(TagContextMenu)`

--- a/src/core/Scanner.ts
+++ b/src/core/Scanner.ts
@@ -8,7 +8,7 @@ import { Camera } from './Camera';
  * This object implements tag scanning logic.
  */
 export class TagScanner extends Camera {
-  private readonly _scanRetries = 2;
+  private readonly _scanRetries = 5;
   private readonly _scanDuration = 2; //seconds
 
   constructor(props: CameraProps) {


### PR DESCRIPTION
This PR addresses [75726](https://dev.azure.com/EquinorASA/DT%20%E2%80%93%20Digital%20Twin/_backlogs/backlog/Ditto/Epics/?workitem=75726)

Other changes:
- No search results is now presented with a toast message
- Cleaned up SearchResults component
- Tag summary is now only shown in development mode
- Scan retries bumped back to 5