### PR TITLE
Feature - User system info

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const LazyCamera = React.lazy(() => import('./EchoCamera'));
 const FallbackLoading = (): JSX.Element => {
   return (
     <DialogGenerator title="Loading Tag Scanner..." actionButtons={[]} open>
-      <Dialog.CustomContent>
+      <Dialog.CustomContent style={{ textAlign: 'center' }}>
         <Progress.Circular
           style={{ margin: 'auto', display: 'block !important' }}
         />

--- a/src/Scanner.tsx
+++ b/src/Scanner.tsx
@@ -9,6 +9,7 @@ import {
   getNotificationDispatcher as dispatchNotification,
   logger
 } from '@utils';
+import { SystemInfoTrigger } from './components/viewfinder/SystemInfoTrigger';
 
 interface ScannerProps {
   stream: MediaStream;
@@ -96,6 +97,9 @@ function Scanner({ stream, viewfinder, canvas, scanArea }: ScannerProps) {
       <ControlPad>
         {tagScanner && (
           <>
+            <SystemInfoTrigger
+              onDelayedTrigger={tagScanner.clipboardThis.bind(tagScanner)}
+            />
             {tagScanner.capabilities?.zoom && (
               <ZoomSlider
                 onSlide={tagScanner.alterZoom}

--- a/src/components/camerabutton/CameraButton.tsx
+++ b/src/components/camerabutton/CameraButton.tsx
@@ -49,6 +49,9 @@ const StyledScannerButton = styled.button`
   height: 75px;
   background-color: var(--white);
   grid-area: shutter;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 `;
 
 const EchoIsSyncingButton = styled(StyledScannerButton)`
@@ -96,6 +99,9 @@ const StyledTorchButton = styled.button`
   height: 55px;
   grid-area: torch;
   border: 1px solid;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 
   &:active {
     background-color: var(--equiBlue1);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,3 +7,4 @@ export { ZoomSlider } from './cameracontrols/zoom/ZoomSlider';
 export { SearchResults } from './searchresults/SearchResults';
 export { ScanningIndicator } from './progress/ScanningLoading';
 export { OverconstrainedAlert } from './error/OverconstrainedAlert';
+export { SystemInfoTrigger } from './viewfinder/SystemInfoTrigger';

--- a/src/components/viewfinder/CaptureArea.tsx
+++ b/src/components/viewfinder/CaptureArea.tsx
@@ -30,6 +30,9 @@ const SvgContainer = styled.section<{ dimensions: Dimensions }>`
   width: ${(props) => props.dimensions.width}px;
   height: ${(props) => props.dimensions.height}px;
   border: 3px dotted var(--outOfService);
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 `;
 
 export { ScanningArea };

--- a/src/components/viewfinder/SystemInfoTrigger.tsx
+++ b/src/components/viewfinder/SystemInfoTrigger.tsx
@@ -1,0 +1,55 @@
+import React, { useRef } from 'react';
+import styled from 'styled-components';
+import {
+  getNotificationDispatcher as dispatchNotification,
+  isLocalDevelopment
+} from '@utils';
+
+interface SystemInfoTriggerProps {
+  onDelayedTrigger: () => Promise<string>;
+}
+
+const SystemInfoTrigger = (props: SystemInfoTriggerProps) => {
+  async function onTriggerSystemInfo() {
+    try {
+      // Workaround for allowing Safari to asynchronously write data to the system clipboard.
+      const clip = new ClipboardItem({
+        'text/plain':
+          // Call this function to get the textual content.
+          props
+            .onDelayedTrigger()
+
+            // Then resolve a Blob construct with the text payload and of the same MIME type.
+            .then((text) => new Blob([text], { type: 'text/plain' }))
+      });
+      await navigator.clipboard.write([clip]);
+      dispatchNotification({
+        message: 'System info was copied to the clipboard',
+        autohideDuration: 3000
+      })();
+    } catch (error) {
+      console.error(
+        'An error occured whilst trying to write to the system clipboard.'
+      );
+      console.error(error);
+    }
+  }
+
+  return <InvisibleButton onClick={onTriggerSystemInfo} />;
+};
+
+const InvisibleButton = styled.button`
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: rgba(0, 0, 0, 0, 1);
+  z-index: 2;
+  width: 50px;
+  height: 50px;
+  border: none;
+  user-select: none;
+  -webkit-user-select: none; /*Safari*/
+  -moz-user-select: none; /*Firefox*/
+`;
+
+export { SystemInfoTrigger };

--- a/src/components/viewfinder/Viewfinder.tsx
+++ b/src/components/viewfinder/Viewfinder.tsx
@@ -45,6 +45,9 @@ const ViewFinder = styled.video`
   height: 100vh;
   object-fit: cover;
   z-index: 1;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 `;
 
 const Canvas = styled.canvas`
@@ -55,6 +58,9 @@ const Canvas = styled.canvas`
   transform: translate(-50%, -50%);
   z-index: {isLocalDevelopment ? 1 : -1}
   //-------//
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 `;
 
 export { Viewfinder };

--- a/src/core/CoreCamera.ts
+++ b/src/core/CoreCamera.ts
@@ -58,6 +58,10 @@ class CoreCamera {
     return this._currentOrientation;
   }
 
+  public get activeCamera() {
+    return this._activeCamera;
+  }
+
   /**
    * Asks the user for permission to use the device camera and resolves a MediaStream object.
    */

--- a/src/core/Scanner.ts
+++ b/src/core/Scanner.ts
@@ -26,7 +26,94 @@ export class TagScanner extends Camera {
     }
   }
 
+  /**
+   * Returns a stringified short report of the users device and configuration.
+   */
+  public async clipboardThis() {
+    return `
+Camera Information
+#################################
+Camera resolution: ${this.viewfinder.videoWidth}x${
+      this.viewfinder.videoHeight
+    }@${this.videoTrack?.getSettings().frameRate}fps.
+Viewfinder resolution (in CSS pixels): ${this.viewfinder.width}x${
+      this.viewfinder.height
+    }.
+Camera is torch capable: ${Boolean(this.capabilities?.torch)}.
+Camera is zoom capable: ${Boolean(this.capabilities?.zoom)}.
+Other camera settings: \n ${getReadableVideotrackSettings.call(this)}
+Current camera facing mode: ${this.activeCamera}
+
+Scanning Area
+#################################
+${getCaptureAreaInfo.call(this)}
+
+Device information
+#################################
+User agent:
+${navigator.userAgent}
+Cameras:
+${await getHRDevices.call(this)}
+Current orientation: ${this.currentOrientation}
+
+`;
+
+    function getReadableVideotrackSettings(this: TagScanner) {
+      let text = '';
+      if (this.videoTrackSettings) {
+        Object.keys(this.videoTrackSettings).forEach((key) => {
+          //@ts-expect-error
+          text += `${key}: ${this.videoTrackSettings[key]}\n`;
+        });
+      } else {
+        text += 'Could not get video tracks';
+      }
+
+      return text;
+    }
+
+    function getHRDevices(this: TagScanner): Promise<string> {
+      return new Promise((resolve) => {
+        let text = '';
+        if (navigator.mediaDevices) {
+          navigator.mediaDevices.enumerateDevices().then((devices) => {
+            devices.forEach((device) => {
+              text += device.label + '\n';
+            });
+            resolve(text);
+          });
+        } else {
+          resolve('Could not enumerate media devices.');
+        }
+      });
+    }
+
+    function getCaptureAreaInfo(this: TagScanner) {
+      const captureArea = document.getElementById('scan-area');
+
+      if (!captureArea) {
+        logger.log('QA', () =>
+          console.warn('A reference to the capture area was not obtainable')
+        );
+        return undefined;
+      }
+      const bcr = captureArea.getBoundingClientRect();
+      const sx = this.viewfinder.videoWidth / 2 - bcr.width / 2;
+      const sy = this.viewfinder.videoHeight / 2 - bcr.height / 2;
+
+      return `
+Dimensions: ${bcr.width}x${bcr.height}
+Intrinsic offset from top: ${sy}.
+Intrinsic offset from left-edge: ${sx}.
+Regular offset from top: ${bcr.y};
+Regular offset from left-edge: ${bcr.x};
+`;
+    }
+  }
+
   public async debugAll(previewCapture = false) {
+    navigator.clipboard.writeText(await this.clipboardThis());
+
     const scanArea = document.getElementById('scan-area');
     if (previewCapture && scanArea) {
       let capture = await this.capturePhoto(scanArea.getBoundingClientRect());


### PR DESCRIPTION
This PR adds the ability for users to copy a full report on the camera to their clipboard as plain text.
The triggering button is hidden on purpose.

![image](https://user-images.githubusercontent.com/10920843/186148307-9f909987-e80c-4461-8e1d-b766f5642628.png)
Image shows what happens after the button is triggered. The red area shows the approximate location of a very small button.

### Here is an example of what a report contains
```
Camera Information
#################################
Camera resolution: 412x480@60fps.
Viewfinder resolution (in CSS pixels): 412x915.
Camera is torch capable: false.
Camera is zoom capable: false.
Other camera settings: 
 aspectRatio: 1.5533980582524272
brightness: 128
colorTemperature: 5924
contrast: 32
deviceId: a874c50ce1a7f877e5d365c7ef7738d4881d76a22876cd61f0b708422936dc45
exposureMode: continuous
exposureTime: 5
focusDistance: 85
focusMode: continuous
frameRate: 60
groupId: 0df06f59eb162611b65123f383843de0f8c4d0e204e229307c092e05a00a820b
height: 412
resizeMode: crop-and-scale
saturation: 32
sharpness: 72
whiteBalanceMode: continuous
width: 640

Current camera facing mode: undefined

Scanning Area
#################################

Dimensions: 329.59375x305
Intrinsic offset from top: 87.5.
Intrinsic offset from left-edge: 41.203125.
Regular offset from top: 305;
Regular offset from left-edge: 41.203125;


Device information
#################################
User agent:
Mozilla/5.0 (Linux; Android 10; SM-G981B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
Cameras:

UVC Camera (046d:0823) (046d:0823)


Current orientation: portrait

```